### PR TITLE
linux-raspberrypi-dev: Switch to rpi-4.12.y

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -7,8 +7,8 @@ python __anonymous() {
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
-LINUX_VERSION ?= "4.11"
-LINUX_RPI_DEV_BRANCH ?= "rpi-4.11.y"
+LINUX_VERSION ?= "4.12"
+LINUX_RPI_DEV_BRANCH ?= "rpi-4.12.y"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = "git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_DEV_BRANCH} \


### PR DESCRIPTION
Linux v4.12 is now released.

Signed-off-by: Paul Barker <pbarker@toganlabs.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
